### PR TITLE
Take in Directory and recursively add all MP3 tracks in Folder and Subfolders

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -4,6 +4,7 @@ var Discord = require('discord.js');
 var http = require('http');
 var logger = require('winston');
 var auth = require('./auth.json');
+var fs = require('fs');
 
 // Configure logger settings
 logger.remove(logger.transports.Console);
@@ -18,6 +19,15 @@ const client = new Discord.Client();
 // For future reference:
 // https://nodejs.org/en/knowledge/HTTP/clients/how-to-create-a-HTTP-request/
 // https://nodejs.org/api/http.html
+
+/*
+	Potential Roadmap Features:
+		1. *DONE* Accepting a directory path and adding all tracks in the given directory (and recursively sub directories).
+		2. A dice roller. Commands for dice in a given DND set (1d4, 1d6, 1d8, 1d10, 1d12, 1d20) and then a custom command given # of dice with N sides.
+		3. Command to display the current playlist and parameters (isLoopingSong, isLoopingQueue, volume).
+		4. Random flag for playing random songs in the playlist.
+		5. Ability to get character sheets from DNDBeyond API (if the API is freely accessible with decent documentation...).
+*/
 
 // Global Vars
 var isReady = true;
@@ -104,6 +114,25 @@ client.on('message', message => {
 			isReady = true;
 		}
 		
+		/*
+			Play a given track / add a track to the queue
+			NOTE: Will not play tracks with quotation marks in the middle of the given title.
+				  Only accepts tracks in the immediate folder or sub-folders, as so:
+				  
+				  !play file_name.mp3
+				  !play "name_with_spaces.mp3"
+				  !play "Sub Folder\some track name.mp3"
+		*/
+		if (command === 'play') {
+			isReady = false;
+			if (args.length > 0) {
+				parseTrackArgs(args, message);
+			} else {
+				message.channel.send('No track given!');
+			}
+			isReady = true;
+		}
+		
 		// Pause the StreamDispatcher
 		if (command === 'pause') {
 			isReady = false;
@@ -163,47 +192,6 @@ client.on('message', message => {
 				// Reset the flag to let the queue end
 				message.channel.send('No longer looping the playlist!');
 				isLoopingQueue = false
-			}
-			isReady = true;
-		}
-		
-		/*
-			Play a given track / add a track to the queue
-			NOTE: Will not play tracks with quotation marks in the middle of the given title.
-				  To play a track in a SUBFOLDER:
-				  
-				  !play "Sub Folder/track name in files.mp3"
-		*/
-		if (command === 'play') {
-			isReady = false;
-			if (args.length > 0) {
-				let track = args[0];
-				// Check if this is a nested filepath with quotations
-				if (args[0].search('"') !== -1) {
-					// Build the full filepath
-					let filePath = '';
-					args.forEach(
-						(arg) => {
-							let quoteIdx = arg.search('"');
-							if (quoteIdx == 0) {
-								// Remove the first quotation mark
-								let fixedArg = arg.substring(quoteIdx + 1) + ' ';
-								filePath += fixedArg;
-							} else if (quoteIdx !== -1) {
-								// Remove the last quotation mark
-								let fixedArg = arg.slice(0, -1);
-								filePath += fixedArg;
-							} else {
-								// Add anything inbetween
-								filePath += arg + ' ';
-							}
-						})
-						track = filePath;
-				}
-				// Play it or add it to the queue
-				playOrAddTrack('./' + track, message);
-			} else {
-				message.channel.send('No track given!');
 			}
 			isReady = true;
 		}
@@ -301,14 +289,92 @@ client.on('message', message => {
 });
 
 /*
+	Name: parseTrackArgs
+	Description: Parse the arguments for the track name
+	Params:
+		args: array, given array of arguments. Typically means a file path with spaces
+		message: object, the DiscordJS message object
+*/
+function parseTrackArgs(args, message) {
+	// Set track to the first arg
+	let track = args[0];
+	let filePath = track;
+	
+	// Check if this is a filepath with quotations
+	if (args[0].search('"') !== -1) {
+		// Build the full filepath
+		filePath = '';
+		args.forEach(
+			(arg) => {
+				let quoteIdx = arg.search('"');
+				if (quoteIdx == 0) {
+					// Remove the first quotation mark
+					let fixedArg = arg.substring(quoteIdx + 1) + ' ';
+					filePath += fixedArg;
+				} else if (quoteIdx !== -1) {
+					// Remove the last quotation mark
+					let fixedArg = arg.slice(0, -1);
+					filePath += fixedArg;
+				} else {
+					// Add anything inbetween
+					filePath += arg + ' ';
+				}
+		})
+		track = filePath;
+	}
+	
+	// Use the filesystem to check if this is a file or a directory
+	let fileInfo = fs.lstatSync(track);
+	if (fileInfo.isFile()) {
+		// Play it or add it to the queue
+		playOrAddTrack('./' + track, message);
+	} else if (fileInfo.isDirectory()) {
+		// Recursively access the directory to grab all files and add them to the queue
+		recursivelyAddAllTracksInDirectory(track, message);
+	}
+}
+
+/*
+	Name: recursivelyAddAllTracksInDirectory
+	Description: Take in a directory path and add all tracks to the queue from this folder and subfolders
+				 NOTE: Will only bulk add MP3 files (for safety)
+	Params:
+		dirPath: string, the directory path
+		message: object, the DiscordJS message object
+*/
+async function recursivelyAddAllTracksInDirectory(dirPath, message) {
+	// Get all folders and files in dirPath
+	const files = await fs.promises.readdir(dirPath);
+	
+	for(const file of files) {
+		let path = dirPath + "\\" + file;
+		let fileStat = fs.lstatSync(path);
+		
+		// Check for file or folder
+		if (fileStat.isFile()) {
+			// Check the file extension
+			let fileExt = path.split(".").pop();
+			if (fileExt == "mp3") {
+				// Add it to the queue
+				playOrAddTrack(path, message, true);
+			}
+		} else if (fileStat.isDirectory()) {
+			// Go into the directory
+			recursivelyAddAllTracksInDirectory(path, message);
+		}
+	}
+}
+
+/*
 	Name: playOrAddTrack
 	Description: If nothing is currently playing, plays the given file.
 				 Otherwise, add the given file to the queue to be played after.
 	Params: 
 		trackTitle: string, the fully qualified location of the given track to be played
 		message: object, the given message object from Discord
+		bulkAdd: boolean, flag to send a message about songs added to the queue if we're not bulk adding
 */
-function playOrAddTrack(trackTitle, message) {
+function playOrAddTrack(trackTitle, message, bulkAdd = false) {
 	if (channelConnection) {
 		// Determine if we are already have a queue
 		if (trackQueue.length === 0) {
@@ -329,7 +395,10 @@ function playOrAddTrack(trackTitle, message) {
 		} else {
 			// Add it to the queue to be played later
 			trackQueue.push(trackTitle);
-			message.channel.send('Added to the queue: ' + trackTitle);
+			if (!bulkAdd) {
+				// Only send the message to the channel if we're not bulk adding songs
+				message.channel.send('Added to the queue: ' + trackTitle);
+			}
 		}
 	}
 }
@@ -351,7 +420,7 @@ function loopSong() {
 	Name: nextInQueue
 	Description: Moves the needle to the next track in queue.
 				 If we are looping the queue, this handles resetting to the first track.
-				 If we aren't looping the queue, this handles resetting it once the queue reaches the end.
+				 If we aren't looping the queue, this handles emptying it once the queue reaches the end.
 */
 function nextInQueue() {
 	// Move to the next track in the queue
@@ -393,7 +462,7 @@ function nextInQueue() {
 /*
 	Name: setBotPresence
 	Description: Set the bot's visual presence in Discord.
-				The two options are:
+				 The two options are:
 					Do Not Disturb, PLAYING - fileName
 					Available, no activity
 	


### PR DESCRIPTION
- Added Node.js File System, `fs`.
- Added potential road map comment.
- Moved bulk of the `play` command into its own function.
- Added function to recursively search a given folder path for all files and folders. This will bulk add any MP3s found along the way.
- Added flag to suppress the "Added to queue" message while bulk adding this way.